### PR TITLE
refactor: change manual cache writes for refetchQuery

### DIFF
--- a/src/components/ExerciseTable.jsx
+++ b/src/components/ExerciseTable.jsx
@@ -9,7 +9,12 @@ function ExerciseTable({ exercises, ITEMS_PER_PAGE }) {
   const navigate = useNavigate()
 
   const [deleteExercise] = useMutation(DELETE_EXERCISE_MUTATION, {
-    refetchQueries: [{ query: EXERCISES_QUERY }],
+    refetchQueries: [
+      {
+        query: EXERCISES_QUERY,
+        variables: { first: 10, after: null, last: null, before: null }
+      }
+    ],
     onError: err => {
       console.error("Error deleting exercise:", err)
       toast.error("Error deleting exercise")
@@ -21,26 +26,7 @@ function ExerciseTable({ exercises, ITEMS_PER_PAGE }) {
 
   const handleDeleteExercise = id => {
     if (confirm("Are you sure you want to delete this exercise?")) {
-      deleteExercise({
-        variables: { input: { id } },
-        update: (cache, { data }) => {
-          if (data?.deleteExercise?.success) {
-            cache.modify({
-              fields: {
-                exercises(existingExerciseConnections = {}) {
-                  const { edges = [] } = existingExerciseConnections
-                  return {
-                    ...existingExerciseConnections,
-                    edges: edges.filter(
-                      edge => id !== edge.node.__ref.split(":")[1]
-                    )
-                  }
-                }
-              }
-            })
-          }
-        }
-      })
+      deleteExercise({ variables: { input: { id } } })
     }
   }
 

--- a/src/pages/coach/exercises/ExercisesPage.jsx
+++ b/src/pages/coach/exercises/ExercisesPage.jsx
@@ -8,8 +8,7 @@ export default function ExercisesPage() {
   const [currentPage, setCurrentPage] = useState(1)
 
   const { loading, error, data, fetchMore } = useQuery(EXERCISES_QUERY, {
-    variables: { first: ITEMS_PER_PAGE, after: null, last: null, before: null },
-    fetchPolicy: "network-only"
+    variables: { first: ITEMS_PER_PAGE, after: null, last: null, before: null }
   })
 
   if (error) return <p>Error: {error.message}</p>


### PR DESCRIPTION
## Description
- Replaced custom useGraphQLMutation hook with Apollo Client's useMutation
- Updated refetchQueries in create and delete exercise

## What does this PR do?
- [ ] Bugfix
- [ ] New feature
- [x] Refactor
- [ ] Documentation

## What are the relevant issues?
- [x] Jira issue [JIRA]()

---

## Checklist
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project
  - [Git Style Guide](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25264131/Git+Guidelines)
  - [Code Review Guidelines](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25067538/Code+Review+Guidelines)
